### PR TITLE
[BugFix] [Jackson databind dependency bumped]

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -168,8 +168,8 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -621,8 +621,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.8.11</version>
-                <scope>provided</scope>
+                <version>2.11.0</version>
             </dependency>
             <!-- Solr Dependencies -->
             <dependency>


### PR DESCRIPTION
- due to Jackson Databind 2.8.11 security vulnerability
- bumped to 2.11.0 as advised on Maven Repository